### PR TITLE
feat: add makeStylesInlineFromString to support raw HTML strings

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,6 @@
-import { makeStylesInline } from './src/utils/makeStylesInline';
+import {
+  makeStylesInline,
+  makeStylesInlineFromString,
+} from './src/utils/makeStylesInline';
 
-export { makeStylesInline };
+export { makeStylesInline, makeStylesInlineFromString };

--- a/src/utils/makeStylesInline.test.ts
+++ b/src/utils/makeStylesInline.test.ts
@@ -1,4 +1,7 @@
-import { makeStylesInline, makeStylesInlineFromString } from './makeStylesInline';
+import {
+  makeStylesInline,
+  makeStylesInlineFromString,
+} from './makeStylesInline';
 import * as fs from 'fs';
 
 describe('renderEmailFromTemplate', () => {
@@ -10,30 +13,32 @@ describe('renderEmailFromTemplate', () => {
     cta_text: 'See all features',
   };
   const expectedHtml = `<html>
-    <head>
-      <title>Test title</title>
-    </head>
-    <body>
-      <div style="position: relative; z-index: 20; max-width: 512px; padding-left: 1rem; padding-top: 2.5rem;">
-        <span style="margin-right: 1.25rem; color: #fde047;">Welcome, John Doe</span>
-      </div>
-      <div>
-        <a href="https://example.com" style="background-color: #3b82f6;">See all features</a>
-        <div style="background-image: url('https://example.com/custom-image.png'); background-repeat: no-repeat;"></div>
-      </div>
-    </body>
-  </html>`;
-  
-  const normalizeHtml = (html: string) => html.replace(/\s+/g, '').trim();
+  <head>
+    <title>Test title</title>
+  </head>
+  <body>
+    <div style="position: relative; z-index: 20; max-width: 512px; padding-left: 1rem; padding-top: 2.5rem;">
+      <span style="margin-right: 1.25rem; color: #fde047;">Welcome, John Doe</span>
+    </div>
+    <div>
+      <a href="https://example.com" style="background-color: #3b82f6;">See all features</a>
+      <div style="background-image: url('https://example.com/custom-image.png'); background-repeat: no-repeat;"></div>
+    </div>
+  </body>
+</html>
+`;
 
   test('should render email from template', async () => {
     const inlinedHtml = await makeStylesInline(templatePath, placeholderValues);
-    expect(normalizeHtml(inlinedHtml)).toEqual(normalizeHtml(expectedHtml));
+    expect(inlinedHtml).toEqual(expectedHtml);
   });
 
   test('should render email from raw template string', async () => {
     const rawString = fs.readFileSync(templatePath, 'utf8');
-    const inlinedHtml = await makeStylesInlineFromString(rawString, placeholderValues);
-    expect(normalizeHtml(inlinedHtml)).toEqual(normalizeHtml(expectedHtml));
+    const inlinedHtml = await makeStylesInlineFromString(
+      rawString,
+      placeholderValues,
+    );
+    expect(inlinedHtml).toEqual(expectedHtml);
   });
 });

--- a/src/utils/makeStylesInline.test.ts
+++ b/src/utils/makeStylesInline.test.ts
@@ -1,32 +1,39 @@
-import { makeStylesInline } from './makeStylesInline';
+import { makeStylesInline, makeStylesInlineFromString } from './makeStylesInline';
+import * as fs from 'fs';
 
 describe('renderEmailFromTemplate', () => {
   const templatePath = 'src/mocks/example-template.html';
+  const placeholderValues = {
+    name: 'John Doe',
+    thank_you: 'Thank you for signing up!',
+    cta_link: 'https://example.com',
+    cta_text: 'See all features',
+  };
+  const expectedHtml = `<html>
+    <head>
+      <title>Test title</title>
+    </head>
+    <body>
+      <div style="position: relative; z-index: 20; max-width: 512px; padding-left: 1rem; padding-top: 2.5rem;">
+        <span style="margin-right: 1.25rem; color: #fde047;">Welcome, John Doe</span>
+      </div>
+      <div>
+        <a href="https://example.com" style="background-color: #3b82f6;">See all features</a>
+        <div style="background-image: url('https://example.com/custom-image.png'); background-repeat: no-repeat;"></div>
+      </div>
+    </body>
+  </html>`;
+  
+  const normalizeHtml = (html: string) => html.replace(/\s+/g, '').trim();
 
   test('should render email from template', async () => {
-    const placeholderValues = {
-      name: 'John Doe',
-      thank_you: 'Thank you for signing up!',
-      cta_link: 'https://example.com',
-      cta_text: 'See all features',
-    };
-
     const inlinedHtml = await makeStylesInline(templatePath, placeholderValues);
+    expect(normalizeHtml(inlinedHtml)).toEqual(normalizeHtml(expectedHtml));
+  });
 
-    expect(inlinedHtml).toEqual(`<html>
-  <head>
-    <title>Test title</title>
-  </head>
-  <body>
-    <div style="position: relative; z-index: 20; max-width: 512px; padding-left: 1rem; padding-top: 2.5rem;">
-      <span style="margin-right: 1.25rem; color: #fde047;">Welcome, John Doe</span>
-    </div>
-    <div>
-      <a href="https://example.com" style="background-color: #3b82f6;">See all features</a>
-      <div style="background-image: url('https://example.com/custom-image.png'); background-repeat: no-repeat;"></div>
-    </div>
-  </body>
-</html>
-`);
+  test('should render email from raw template string', async () => {
+    const rawString = fs.readFileSync(templatePath, 'utf8');
+    const inlinedHtml = await makeStylesInlineFromString(rawString, placeholderValues);
+    expect(normalizeHtml(inlinedHtml)).toEqual(normalizeHtml(expectedHtml));
   });
 });

--- a/src/utils/makeStylesInline.ts
+++ b/src/utils/makeStylesInline.ts
@@ -76,24 +76,27 @@ const inlineStyles = async (html: string): Promise<string> => {
 
 const processTemplate = async (
   templateSource: string,
-  data?: { [key: string]: string }
+  data?: { [key: string]: string },
 ): Promise<string> => {
-  const template = Handlebars.compile(templateSource)
-  const html = template(data)
+  const template = Handlebars.compile(templateSource);
+  const html = template(data);
 
-  const inlinedStyles = await inlineStyles(html)
+  const inlinedStyles = await inlineStyles(html);
 
-  return removeCssClasses(inlinedStyles)
-}
+  return removeCssClasses(inlinedStyles);
+};
 
-export const makeStylesInline: TMakeStylesInline = async (templatePath, data) => {
-  const templateSource = fs.readFileSync(templatePath, "utf8")
-  return processTemplate(templateSource, data)
-}
+export const makeStylesInline: TMakeStylesInline = async (
+  templatePath,
+  data,
+) => {
+  const templateSource = fs.readFileSync(templatePath, 'utf8');
+  return processTemplate(templateSource, data);
+};
 
 export const makeStylesInlineFromString = async (
   templateString: string,
-  data?: { [key: string]: string }
+  data?: { [key: string]: string },
 ): Promise<string> => {
-  return processTemplate(templateString, data)
-}
+  return processTemplate(templateString, data);
+};

--- a/src/utils/makeStylesInline.ts
+++ b/src/utils/makeStylesInline.ts
@@ -74,15 +74,26 @@ const inlineStyles = async (html: string): Promise<string> => {
   });
 };
 
-export const makeStylesInline: TMakeStylesInline = async (
-  templatePath,
-  data,
-) => {
-  const templateSource = fs.readFileSync(templatePath, 'utf8');
-  const template = Handlebars.compile(templateSource);
-  const html = template(data);
+const processTemplate = async (
+  templateSource: string,
+  data?: { [key: string]: string }
+): Promise<string> => {
+  const template = Handlebars.compile(templateSource)
+  const html = template(data)
 
-  const inlinedStyles = await inlineStyles(html);
+  const inlinedStyles = await inlineStyles(html)
 
-  return removeCssClasses(inlinedStyles);
-};
+  return removeCssClasses(inlinedStyles)
+}
+
+export const makeStylesInline: TMakeStylesInline = async (templatePath, data) => {
+  const templateSource = fs.readFileSync(templatePath, "utf8")
+  return processTemplate(templateSource, data)
+}
+
+export const makeStylesInlineFromString = async (
+  templateString: string,
+  data?: { [key: string]: string }
+): Promise<string> => {
+  return processTemplate(templateString, data)
+}


### PR DESCRIPTION
### What does this PR do?

Extracts the core styling logic into a reusable internal function and exposes a new `makeStylesInlineFromString` method. This allows users to pass raw HTML strings directly instead of relying on file paths and `fs.readFileSync`.

### Why is this necessary?

In modern full-stack frameworks (like TanStack Start, Next.js, Nuxt) and bundlers like Vite, it's a common pattern to import templates as raw strings (e.g., `import template from './email.hbs?raw'`).

Furthermore, in serverless environments like Vercel or AWS Lambda, dynamically reading files with `fs` often causes `ENOENT` errors because the template files aren't included in the final function bundle by default (due to file tracing limitations). Bypassing the file system completely solves this issue.

### Changes 
- Extracted compilation logic to `processTemplate`.
- Added `makeStylesInlineFromString` exported function.
- Added tests to ensure backward compatibility with the existing `makeStylesInline` function.